### PR TITLE
fix: clsx call in `cn`

### DIFF
--- a/examples/next-js-app/lib/utils.ts
+++ b/examples/next-js-app/lib/utils.ts
@@ -2,7 +2,7 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(...inputs));
 }
 
 /**


### PR DESCRIPTION
was passing the whole array into `clsx`, ts wasn’t happy. now spreading args so it works as intended.
